### PR TITLE
bug(edit-trip): User should be able to edit trip

### DIFF
--- a/__mockData__/tripRequest-mock-data.js
+++ b/__mockData__/tripRequest-mock-data.js
@@ -67,6 +67,7 @@ export const props = {
 	requestTrip: jest.fn(),
 	onClick: jest.fn(),
 	editTripRequest: jest.fn(),
+	setTitle: jest.fn(),
 };
 export const props2 = {
 	tripRequestReducer: {
@@ -134,4 +135,5 @@ export const props2 = {
 	GetAccomodations: jest.fn(),
 	requestTrip: jest.fn(),
 	onClick: jest.fn(),
+	setTitle: jest.fn(),
 };

--- a/__tests__/components/__snapshots__/editProfile/__snapshots__/user.profile.test.js.snap
+++ b/__tests__/components/__snapshots__/editProfile/__snapshots__/user.profile.test.js.snap
@@ -69,7 +69,7 @@ exports[`user profile component should render the user profile  component succes
       </Styled(MuiBox)>
     </Link>
   </Styled(MuiBox)>
-  <WithStyles(withRouter(NavLinks)) />
+  <Connect(WithStyles(withRouter(NavLinks))) />
   <Styled(MuiBox)
     marginTop={1}
   >

--- a/__tests__/main.layout.test.js
+++ b/__tests__/main.layout.test.js
@@ -53,7 +53,7 @@ describe('Render main layout', () => {
 			.first()
 			.simulate('close');
 		const Route = wrapper.find('Route');
-		expect(wrapper.find('div').length).toBe(62);
+		expect(wrapper.find('div').length).toBe(70);
 		expect(wrapper.find('main').length).toBe(1);
 		expect(wrapper.find('Switch').length).toBe(1);
 		expect(wrapper.find('Route').length).toBeGreaterThan(0);

--- a/__tests__/tripRequestTest/tripRequestView.test.js
+++ b/__tests__/tripRequestTest/tripRequestView.test.js
@@ -25,6 +25,7 @@ const setUpEditTrip = (initialState = {}) => {
 	const store = testStore(initialState);
 	props.trip = [
 		{
+			id: 1,
 			reason: 'traveling',
 			accomodationId: 3,
 			From: 1,
@@ -47,7 +48,7 @@ const setUpEditTrip = (initialState = {}) => {
 
 describe('Trip Request component tests', () => {
 	it('should render successfully all breaks found in Trip Request view page', () => {
-		const wrapper = shallow(<TripRequest error={true} />);
+		const wrapper = shallow(<TripRequest error={true} {...props} />);
 		expect(wrapper.find('br').length).toBe(1);
 	});
 

--- a/src/actions/signInAction.js
+++ b/src/actions/signInAction.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 export const USER_SIGNIN_SUCCESS = 'USER_SIGNIN_SUCCESS';
 export const USER_SIGNIN_FAILURE = 'USER_SIGNIN_FAILURE';
-export const USER_LOGOUT = 'USER_LOGOUT';
 import { createBrowserHistory } from 'history';
 import { config } from 'dotenv';
 

--- a/src/actions/tripRequestAction.js
+++ b/src/actions/tripRequestAction.js
@@ -4,9 +4,15 @@ export const REQUEST_TRIP_FAILURE = 'REQUEST_TRIP_FAILURE';
 export const GET_LOCATIONS = 'GET_LOCATIONS';
 export const GET_ACCOMODATION_SUCCESS = 'GET_ACCOMODATION_SUCCESS';
 export const GET_ACCOMODATION_FAILURE = 'GET_ACCOMODATION_FAILURE';
+import { createBrowserHistory } from 'history';
+
 import { config } from 'dotenv';
 
 config();
+
+export const history = createBrowserHistory({
+	forceRefresh: true,
+});
 
 const userToken = `Bearer ${localStorage.getItem('token')}`;
 

--- a/src/helpers/titleGenerator.js
+++ b/src/helpers/titleGenerator.js
@@ -11,6 +11,7 @@ export const titleGenerator = () => {
 const paths = [
 	{ pathName: '/trips', title: 'My Trip Requests' },
 	{ pathName: '/make-trip-request', title: 'Create Trip Request' },
+	{ pathName: '/edit-trip/:id', title: 'Edit Trip Request' },
 	{ pathName: '/profile', title: 'My Profile' },
 	{ pathName: '/trips-stats', title: 'Trips statistics' },
 	{ pathName: '/user/user-role-setting', title: 'User Role Settings' },

--- a/src/layouts/main.layout.jsx
+++ b/src/layouts/main.layout.jsx
@@ -170,6 +170,7 @@ const MainLayout = props => {
 						<Route path='/user/user-role-setting' component={UserRoleSetting} />
 						<Route path='/user-management' component={UserManagement} />
 						<Route path='/make-trip-request' exact component={TripRequest} />
+						<Route path='/edit-trip/:id' exact component={TripRequest} />
 						<Route path='/approval-table' component={ApprovalTable} />
 						<Route path='/trip-request' component={ApprovalsTripRequest} />
 						<Route path='/accommodations' component={AccommodationFacility} />

--- a/src/views/creating_accommodation_facilities/CreateAccommodation.jsx
+++ b/src/views/creating_accommodation_facilities/CreateAccommodation.jsx
@@ -42,8 +42,6 @@ import SwipeableViews from 'react-swipeable-views';
 import { autoPlay } from 'react-swipeable-views-utils';
 import MobileStepper from '@material-ui/core/MobileStepper';
 export const AutoPlaySwipeableViews = autoPlay(SwipeableViews);
-import Footer from "../../components/common/footer";
-import { log } from 'util';
 import Footer from '../../components/common/footer';
 export const history = createBrowserHistory({
 	forceRefresh: true,
@@ -824,8 +822,7 @@ export class AccommodationFacility extends Component {
 					</Grid>
 				</Paper>
 
-				<Footer/>
-				
+				<Footer />
 			</div>
 		);
 	}

--- a/src/views/trip_requests/userTripRequest.view.jsx
+++ b/src/views/trip_requests/userTripRequest.view.jsx
@@ -27,37 +27,67 @@ export const normalizeType = type => {
 	}
 };
 
-export const Request = (props) => {
+export const Request = props => {
 	useEffect(() => {
 		if (!props.trip.length) {
 			props.history.push('/trips');
 		}
-	})
+	});
 
 	const statusColor = status => {
 		return status === 'pending'
 			? '#FBBC05'
 			: status === 'approved'
-				? '#34A853'
-				: '#E10050';
+			? '#34A853'
+			: '#E10050';
 	};
 
-	const Capitalize = (string) => string ? string.charAt(0).toUpperCase() + string.slice(1) : string;
+	const Capitalize = string =>
+		string ? string.charAt(0).toUpperCase() + string.slice(1) : string;
 
 	return (
 		<Box p={2}>
 			<Card>
 				<CardContent>
-					<Grid container justify="space-between" alignItems="center">
-						<Grid item><Typography style={{ fontWeight: "bold", fontSize: 20, color: '#616161' }} variant="h3">{props.trip.length ? normalizeType(props.trip[0].tripType) : ""}</Typography></Grid>
-						<Grid item><Typography style={{ fontSize: 16, color: props.trip.length ? statusColor(props.trip[0].status) : "" }} variant="h3">{props.trip.length ? Capitalize(props.trip[0].status) : ""}</Typography></Grid>
+					<Grid container justify='space-between' alignItems='center'>
+						<Grid item>
+							<Typography
+								style={{ fontWeight: 'bold', fontSize: 20, color: '#616161' }}
+								variant='h3'
+							>
+								{props.trip.length ? normalizeType(props.trip[0].tripType) : ''}
+							</Typography>
+						</Grid>
+						<Grid item>
+							<Typography
+								style={{
+									fontSize: 16,
+									color: props.trip.length
+										? statusColor(props.trip[0].status)
+										: '',
+								}}
+								variant='h3'
+							>
+								{props.trip.length ? Capitalize(props.trip[0].status) : ''}
+							</Typography>
+						</Grid>
 					</Grid>
 					<Box py={1}>
-						<Typography style={{ fontSize: 14, color: '#616161' }} variant="h3">{props.trip.length ? `${Capitalize(props.user.firstName)} ${Capitalize(props.user.lastName)}` : ""}</Typography>
+						<Typography style={{ fontSize: 14, color: '#616161' }} variant='h3'>
+							{props.trip.length
+								? `${Capitalize(props.user.firstName)} ${Capitalize(
+										props.user.lastName,
+								  )}`
+								: ''}
+						</Typography>
 					</Box>
-					<Typography style={{ fontSize: 14, color: '#616161' }} variant="h3">{props.trip.length ? new Date(props.trip[0].createdAt).toDateString() : ""}</Typography>
-					{
-						props.trip.length ? props.trip.map((item, index) => {
+					<Typography style={{ fontSize: 14, color: '#616161' }} variant='h3'>
+						{props.trip.length
+							? new Date(props.trip[0].createdAt).toDateString()
+							: ''}
+					</Typography>
+					{props.trip.length ? (
+						props.trip.map((item, index) => {
 							return (
 								<Box key={index} py={2}>
 									<Grid container>
@@ -67,10 +97,11 @@ export const Request = (props) => {
 													<TextInput
 														disabled={true}
 														id={`origin${index}`}
-														label="Origin"
-														name="origin"
+														label='Origin'
+														name='origin'
 														defaultValue={Capitalize(item.origin)}
-														required={false} />
+														required={false}
+													/>
 												</Box>
 											</Grid>
 											<Grid xs={12} md={4} xl={2} item>
@@ -78,10 +109,11 @@ export const Request = (props) => {
 													<TextInput
 														disabled={true}
 														id={`destination${index}`}
-														label="Destination"
-														name="destination"
+														label='Destination'
+														name='destination'
 														defaultValue={Capitalize(item.destination)}
-														required={false} />
+														required={false}
+													/>
 												</Box>
 											</Grid>
 											<Grid xs={12} md={4} xl={2} item>
@@ -89,32 +121,52 @@ export const Request = (props) => {
 													<TextInput
 														disabled={true}
 														id={`departureDate${index}`}
-														label="Departure Date"
-														name="firstName"
-														defaultValue={new Date(item.departureDate).toDateString()}
-														required={false} />
+														label='Departure Date'
+														name='firstName'
+														defaultValue={new Date(
+															item.departureDate,
+														).toDateString()}
+														required={false}
+													/>
 												</Box>
 											</Grid>
-											{props.trip.length ? props.trip[0].tripType == "round trip" ? <Grid xs={12} md={4} xl={2} item>
-												<Box px={1}>
-													<TextInput
-														disabled={true}
-														id={`returnDate${index}`}
-														label="Return Date"
-														name="returnDate"
-														defaultValue={new Date(item.returnDate).toDateString()}
-														required={false} />
-												</Box>
-											</Grid> : <></> : <></>}
-											<Grid xs={12} md={4} xl={props.trip[0].tripType == "round trip" ? 2 : 4} item>
+											{props.trip.length ? (
+												props.trip[0].tripType == 'round trip' ? (
+													<Grid xs={12} md={4} xl={2} item>
+														<Box px={1}>
+															<TextInput
+																disabled={true}
+																id={`returnDate${index}`}
+																label='Return Date'
+																name='returnDate'
+																defaultValue={new Date(
+																	item.returnDate,
+																).toDateString()}
+																required={false}
+															/>
+														</Box>
+													</Grid>
+												) : (
+													<></>
+												)
+											) : (
+												<></>
+											)}
+											<Grid
+												xs={12}
+												md={4}
+												xl={props.trip[0].tripType == 'round trip' ? 2 : 4}
+												item
+											>
 												<Box px={1}>
 													<TextInput
 														disabled={true}
 														id={`reason${index}`}
-														label="Reason"
-														name="reason"
+														label='Reason'
+														name='reason'
 														defaultValue={Capitalize(item.reason)}
-														required={false} />
+														required={false}
+													/>
 												</Box>
 											</Grid>
 											<Grid xs={12} md={4} xl={2} item>
@@ -122,81 +174,189 @@ export const Request = (props) => {
 													<TextInput
 														disabled={true}
 														id={`accomodation${index}`}
-														label="Accomodation"
-														name="accomodation"
+														label='Accomodation'
+														name='accomodation'
 														defaultValue={Capitalize(item.accomodation)}
-														required={false} />
+														required={false}
+													/>
 												</Box>
 											</Grid>
 										</Grid>
-										{item.booking ? <Box key={index + 2} style={{ display: item.booking.length > 0 ? 'block' : 'none' }} pl={1} pt={1}>
-											<Grid container spacing={1}>
-												<Grid item xs={12}>
-													<Typography style={{ fontSize: 16, color: '#616161' }} variant="h3">Booking info</Typography>
+										{item.booking ? (
+											<Box
+												key={index + 2}
+												style={{
+													display: item.booking.length > 0 ? 'block' : 'none',
+												}}
+												pl={1}
+												pt={1}
+											>
+												<Grid container spacing={1}>
+													<Grid item xs={12}>
+														<Typography
+															style={{ fontSize: 16, color: '#616161' }}
+															variant='h3'
+														>
+															Booking info
+														</Typography>
+													</Grid>
+													<Grid item container spacing={2} xs={12}>
+														<Grid item>
+															<Typography
+																style={{
+																	fontSize: 16,
+																	color: 'rgba(0, 0, 0, 0.38)',
+																}}
+																variant='h3'
+															>
+																Accommodation:{' '}
+															</Typography>
+														</Grid>
+														<Grid item>
+															<Typography
+																style={{ fontSize: 16, color: '#616161' }}
+																variant='h3'
+															>
+																{item.booking.length > 0
+																	? Capitalize(item.booking[0].accomodation)
+																	: ''}{' '}
+															</Typography>
+														</Grid>
+													</Grid>
+													<Grid item container spacing={2} xs={12}>
+														<Grid item>
+															<Typography
+																style={{
+																	fontSize: 16,
+																	color: 'rgba(0, 0, 0, 0.38)',
+																}}
+																variant='h3'
+															>
+																Room type:{' '}
+															</Typography>
+														</Grid>
+														<Grid item>
+															<Typography
+																style={{ fontSize: 16, color: '#616161' }}
+																variant='h3'
+															>
+																{item.booking.length > 0
+																	? Capitalize(item.booking[0].name)
+																	: ''}{' '}
+															</Typography>
+														</Grid>
+													</Grid>
+													<Grid item container spacing={2} xs={12}>
+														<Grid item>
+															<Typography
+																style={{
+																	fontSize: 16,
+																	color: 'rgba(0, 0, 0, 0.38)',
+																}}
+																variant='h3'
+															>
+																Room number:{' '}
+															</Typography>
+														</Grid>
+														<Grid item>
+															<Typography
+																style={{ fontSize: 16, color: '#616161' }}
+																variant='h3'
+															>
+																{item.booking.length > 0
+																	? item.booking[0].roomid
+																	: ''}{' '}
+															</Typography>
+														</Grid>
+													</Grid>
 												</Grid>
-												<Grid item container spacing={2} xs={12}>
-													<Grid item>
-														<Typography style={{ fontSize: 16, color: 'rgba(0, 0, 0, 0.38)' }} variant="h3">Accommodation: </Typography>
-													</Grid>
-													<Grid item>
-														<Typography style={{ fontSize: 16, color: '#616161' }} variant="h3">{item.booking.length > 0 ? Capitalize(item.booking[0].accomodation) : ""} </Typography>
-													</Grid>
+											</Box>
+										) : (
+											<div />
+										)}
+										{item.booking ? (
+											<Grid
+												key={index + 3}
+												style={{
+													display: item.booking.length > 0 ? 'none' : 'flex',
+												}}
+												container
+												justify='space-between'
+												alignItems='flex-end'
+											>
+												<Grid item>
+													<Box py={1} />
+													<Button
+														id='btn_edit_booking'
+														disableElevation
+														variant='contained'
+														color='primary'
+														onClick={() => {
+															if (
+																props.trip.length &&
+																props.trip[0].status.toLowerCase() ==
+																	'Approved'.toLowerCase()
+															) {
+																props.selectTripToBookAccommodationAction({
+																	id: item.id,
+																	destination: item.destination,
+																	accommodationId: item.accommodationId,
+																});
+																props.history.push(
+																	'/booking/3d85c8c7-9ee3-4e06-bf94-0630c7dd01d2',
+																);
+															} else {
+																props.history.push(
+																	`/edit-trip/${
+																		props.trip.length ? item.id : 0
+																	}`,
+																);
+															}
+														}}
+													>
+														{props.trip.length
+															? props.trip[0].status.toLowerCase() ==
+															  'Approved'.toLowerCase()
+																? 'Book accommodation'
+																: 'Edit'
+															: ''}
+													</Button>
 												</Grid>
-												<Grid item container spacing={2} xs={12}>
-													<Grid item>
-														<Typography style={{ fontSize: 16, color: 'rgba(0, 0, 0, 0.38)' }} variant="h3">Room type: </Typography>
-													</Grid>
-													<Grid item>
-														<Typography style={{ fontSize: 16, color: '#616161' }} variant="h3">{item.booking.length > 0 ? Capitalize(item.booking[0].name) : ""} </Typography>
-													</Grid>
-												</Grid>
-												<Grid item container spacing={2} xs={12}>
-													<Grid item>
-														<Typography style={{ fontSize: 16, color: 'rgba(0, 0, 0, 0.38)' }} variant="h3">Room number: </Typography>
-													</Grid>
-													<Grid item>
-														<Typography style={{ fontSize: 16, color: '#616161' }} variant="h3">{item.booking.length > 0 ? item.booking[0].roomid : ""} </Typography>
-													</Grid>
+												<Grid item>
+													<Box py={1} />
+													<Typography
+														style={{ fontSize: 16, color: '#616161' }}
+														variant='h3'
+													>
+														Managed by :{' '}
+														{props.trip.length
+															? `${Capitalize(
+																	props.trip[0].manager.firstName,
+															  )} ${Capitalize(
+																	props.trip[0].manager.lastName,
+															  )}`
+															: ''}
+													</Typography>
 												</Grid>
 											</Grid>
-										</Box> : <div />}
-										{item.booking ? <Grid key={index + 3} style={{ display: item.booking.length > 0 ? 'none' : 'flex' }} container justify="space-between" alignItems="flex-end">
-											<Grid item>
-												<Box py={1} />
-												<Button id="btn_edit_booking" disableElevation variant="contained" color="primary" onClick={() => {
-													if (props.trip.length && props.trip[0].status.toLowerCase() == "Approved".toLowerCase()) {
-														props.selectTripToBookAccommodationAction({
-															id: item.id,
-															destination: item.destination,
-															accommodationId: item.accommodationId
-														})
-														props.history.push('/booking/3d85c8c7-9ee3-4e06-bf94-0630c7dd01d2')
-													}
-													else {
-														props.history.push('/make-trip-request');
-													}
-												}}>
-													{props.trip.length ? props.trip[0].status.toLowerCase() == "Approved".toLowerCase() ? "Book accommodation" : "Edit" : ""}
-												</Button>
-											</Grid>
-											<Grid item>
-												<Box py={1} />
-												<Typography style={{ fontSize: 16, color: '#616161' }} variant="h3">Managed by : {props.trip.length ? `${Capitalize(props.trip[0].manager.firstName)} ${Capitalize(props.trip[0].manager.lastName)}` : ''}</Typography>
-											</Grid>
-										</Grid> : <div />}
+										) : (
+											<div />
+										)}
 									</Grid>
 								</Box>
-							)
-						}) : <div />
-					}
+							);
+						})
+					) : (
+						<div />
+					)}
 				</CardContent>
 			</Card>
 			<Container style={{ paddingTop: 42 }}>
-				<Comments tripId={props.trip.length ? props.trip[0].tripId : ""} />
+				<Comments tripId={props.trip.length ? props.trip[0].tripId : ''} />
 			</Container>
-		</Box >
-	)
-}
+		</Box>
+	);
+};
 
 export const mapStateToProps = state => {
 	return {
@@ -205,4 +365,6 @@ export const mapStateToProps = state => {
 	};
 };
 
-export default connect(mapStateToProps, { selectTripToBookAccommodationAction })(withRouter(Request));
+export default connect(mapStateToProps, {
+	selectTripToBookAccommodationAction,
+})(withRouter(Request));

--- a/src/views/triprequest.view.jsx
+++ b/src/views/triprequest.view.jsx
@@ -13,9 +13,12 @@ import {
 	requestTrip,
 	GetAccomodations,
 	editTripRequest,
+	history,
 } from '../actions/tripRequestAction.js';
 import { connect } from 'react-redux';
 import withWidth from '@material-ui/core/withWidth';
+import { titleGenerator } from '../helpers/titleGenerator.js';
+import { setTitle } from '../actions/main.layout.action';
 
 const styles = {
 	tabs: {
@@ -141,6 +144,10 @@ export class TripRequest extends Component {
 			buttonState: true,
 			tripSubmitted: false,
 		};
+		!this.state.trip && this.props.history
+			? (this.props.history.push('/make-trip-request'),
+			  this.props.setTitle('Create Trip Request'))
+			: this.props.setTitle('Edit Trip Request');
 	}
 
 	handleIndexChange = (event, value) => {
@@ -459,9 +466,18 @@ export class TripRequest extends Component {
 						onChange={this.handleIndexChange}
 						style={styles.tabs}
 					>
-						<Tab label='One Way Trip' />
-						<Tab label='Round Trip' />
-						<Tab label='Multi City Trip' />
+						<Tab
+							label='One Way Trip'
+							disabled={this.props.trip && index !== 0 && true}
+						/>
+						<Tab
+							label='Round Trip'
+							disabled={this.props.trip && index !== 1 && true}
+						/>
+						<Tab
+							label='Multi City Trip'
+							disabled={this.props.trip && index !== 2 && true}
+						/>
 					</Tabs>
 					{this.state.index !== 2 ? (
 						<OneWay
@@ -688,6 +704,8 @@ const request = connect(mapStateToProps, {
 	requestTrip,
 	GetAccomodations,
 	editTripRequest,
+	history,
+	setTitle,
 })(withWidth()(TripRequest));
 
 export default request;


### PR DESCRIPTION
#### What does this PR do?
It fixes all issues that occurred when editing trip requests
#### Description of Task to be completed?
- insure that we only show tab of the trip going to be edited and hide others
- each trip will have a specific route when you refresh you get redirected to create trip request
#### How should this be manually tested?
- Go to the browser and run `https://blackninjas-frontend-staging.herokuapp.com/trips`
- select specific trip `https://blackninjas-frontend-staging.herokuapp.com/trips/160`
- Click on edit to edit the trip requests `https://blackninjas-frontend-staging.herokuapp.com/160/edit-trip`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![edit](https://user-images.githubusercontent.com/51251401/78126826-6bccb580-7413-11ea-88c7-8afc2a6e6dd7.png)


#### Questions:
- N/A