### PR TITLE
changing accommodation font size

### DIFF
--- a/src/components/profile/Nav.links.jsx
+++ b/src/components/profile/Nav.links.jsx
@@ -266,7 +266,7 @@ export class NavLinks extends Component {
 								to='/create-accommodations'
 								style={{ textDecoration: 'none' }}
 							>
-								<Typography style={{ fontSize: '20px' }}>
+								<Typography >
 									Accommodations
 								</Typography>
 							</Link>


### PR DESCRIPTION
### What does this PR do?
It changes the font size of accommodation on sidebar nav link
### Description of Task to be completed?
-  fixing the issue of the font size of accommodation on sidebar nav link
#### How should this be manually tested?
- Go to the browser and run `https://blackninjas-frontend-staging.herokuapp.com/create-accommodations`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
Before changing
<img width="1440" alt="Screen Shot 2020-03-30 at 12 54 33" src="https://user-images.githubusercontent.com/52497006/77904940-b1f40e80-7285-11ea-9e28-0dea700fba0e.png">
After changing
<img width="1440" alt="Screen Shot 2020-03-30 at 12 54 41" src="https://user-images.githubusercontent.com/52497006/77904962-ba4c4980-7285-11ea-9f12-ac21b008b9b2.png">

#### Questions:
- N/A